### PR TITLE
(UNetReceiver): reset cache's crc in disabled mode.

### DIFF
--- a/extensions/UNetUDP/UNetReceiver.cc
+++ b/extensions/UNetUDP/UNetReceiver.cc
@@ -656,6 +656,10 @@ namespace uniset
             {
                 unetcrit << myname << "(updateEvent): mode update error: " << ex.what() << std::endl;
             }
+
+            // сброс при включении режима mEnabled
+            if( trOnMode.hi( mode == Mode::mEnabled ) )
+                forceUpdate();
         }
 
         if( sidRespond != DefaultObjectId )

--- a/extensions/UNetUDP/UNetReceiver.h
+++ b/extensions/UNetUDP/UNetReceiver.h
@@ -315,6 +315,8 @@ namespace uniset
             size_t cacheMissed; // количество промахов
             bool ignoreCRC = { false }; /*!< отключение проверки crc */
 
+            Trigger trOnMode; /*!< триггер на включение режима mEnabled */
+
             CacheInfo* getDCache( UniSetUDP::UDPMessage* upack ) noexcept;
             CacheInfo* getACache( UniSetUDP::UDPMessage* pack ) noexcept;
     };


### PR DESCRIPTION
После перехода в режим "отключено", допустим, поменялись данные в шаре, но сами данные в пакете не поменялись. При переходе в режим включено данные должны заново считаться и обновить данные в шаре на действительные. Но если контрольная сумма не меняется, то пакет и данные в нем отбрасываются пока не поменяется что-то в пакете. А если принудительно сбросить crc в кэш, то при включении режима работы произойдет обновление данных. 
Данные могут меняться если у нас два узла выставляют один и тот же датчик в шаре, в зависимости от того с которого узла сейчас читаем данные.